### PR TITLE
Adds exclude mixin + tests

### DIFF
--- a/scss/pack/seed-publish/__index.scss
+++ b/scss/pack/seed-publish/__index.scss
@@ -3,5 +3,4 @@
 // Config
 @import "./config";
 // Mixins
-@import "./mixins/export";
-@import "./mixins/publish";
+@import "./mixins/_index";

--- a/scss/pack/seed-publish/mixins/__index.scss
+++ b/scss/pack/seed-publish/mixins/__index.scss
@@ -1,0 +1,5 @@
+// Mixins :: Index
+
+@import "./exclude";
+@import "./export";
+@import "./publish";

--- a/scss/pack/seed-publish/mixins/_exclude.scss
+++ b/scss/pack/seed-publish/mixins/_exclude.scss
@@ -1,0 +1,21 @@
+// Mixins :: Exclude
+
+// Dependencies
+@import "../config";
+
+@mixin exclude($keys...) {
+  @if $keys == false {
+    @error "exclude: An argument must be defined.";
+  }
+  @each $key in $keys {
+    @if (type-of($key) == "string") {
+      $__seed-publish-list: map-merge($__seed-publish-list, ($key: true)) !global;
+    }
+    @else if (type-of($key) == "list") {
+      @each $k in $key {
+        // Recursively exclude
+        @include exclude($k);
+      }
+    }
+  }
+}

--- a/scss/pack/seed-publish/mixins/_publish.scss
+++ b/scss/pack/seed-publish/mixins/_publish.scss
@@ -16,4 +16,3 @@
     @error "publish: The argument must be a string.";
   }
 }
-

--- a/scss/pack/seed-publish/mixins/test/_exclude.scss
+++ b/scss/pack/seed-publish/mixins/test/_exclude.scss
@@ -1,0 +1,166 @@
+// Test :: exclude
+
+@import "true";
+@import "../exclude";
+@import "../export";
+@import "../publish";
+
+@include test-module("Mixin: exclude") {
+
+  @include test("should prevent exports of pre-published content") {
+    @include assert("outputs") {
+      @include output {
+        background: pink;
+
+        $key: test-001;
+        @include exclude($key);
+
+        // Mock export + publish
+        @include export($key) {
+          margin: 0;
+        }
+        @include publish($key);
+      }
+      @include expect {
+        background: pink;
+      }
+    }
+  }
+
+  @include test("should accept a list as an argument") {
+    @include assert("outputs") {
+      @include output {
+        background: pink;
+
+        $key: test-002;
+        $key2: _test-a;
+        @include exclude(($key, $key2));
+
+        // Mock export + publish
+        @include export($key) {
+          margin: 0;
+        }
+        @include publish($key);
+
+        // Mock export + publish
+        @include export($key2) {
+          margin: 0;
+        }
+        @include publish($key2);
+      }
+      @include expect {
+        background: pink;
+      }
+    }
+  }
+
+  @include test("should accept a nested list as an argument") {
+    @include assert("outputs") {
+      @include output {
+        background: pink;
+
+        $key: test-002a;
+        $key2: test-002b;
+        $key3: test-002b;
+        @include exclude(($key, ($key2, $key3)));
+
+        // Mock export + publish
+        @include export($key) {
+          margin: 0;
+        }
+        @include publish($key);
+        // Mock export + publish
+        @include export($key2) {
+          margin: 0;
+        }
+        @include publish($key2);
+        // Mock export + publish
+        @include export($key3) {
+          margin: 0;
+        }
+        @include publish($key3);
+      }
+      @include expect {
+        background: pink;
+      }
+    }
+  }
+
+  @include test("should accept a mixture of strings and lists as an argument") {
+    @include assert("outputs") {
+      @include output {
+        background: pink;
+
+        $key: test-002ab;
+        $key2: test-002bb;
+        $key3: test-002cb;
+        @include exclude($key, ($key2, $key3));
+
+        // Mock export + publish
+        @include export($key) {
+          margin: 0;
+        }
+        @include publish($key);
+        // Mock export + publish
+        @include export($key2) {
+          margin: 0;
+        }
+        @include publish($key2);
+        // Mock export + publish
+        @include export($key3) {
+          margin: 0;
+        }
+        @include publish($key3);
+      }
+      @include expect {
+        background: pink;
+      }
+    }
+  }
+
+  @include test("should allow for mulitple excludes") {
+    @include assert("outputs") {
+      @include output {
+
+        $key: test-003;
+        @include exclude($key);
+        background: pink;
+        @include exclude($key);
+
+        // Mock export + publish
+        @include export($key) {
+          margin: 0;
+        }
+        @include publish($key);
+      }
+      @include expect {
+        background: pink;
+      }
+    }
+  }
+
+  @include test("should not affect published keys") {
+    @include assert("outputs") {
+      @include output {
+
+        $key: test-004;
+        @include exclude($key);
+        background: pink;
+
+        // Mock export + publish
+        @include export($key) {
+          margin: 0;
+        }
+        @include publish($key);
+        @include exclude($key);
+        // Re-export
+        @include export($key) {
+          margin: 0;
+        }
+      }
+      @include expect {
+        background: pink;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Exclude allows you to prevent content that **will** be published during the CSS compile stage.

Example:

``` scss
@include exclude(thing);

@include export(thing) {
  .thing {
    background: black;
  }
}
@include publish(thing);
```

Even though the `thing` module is exported and published, it will not be included in the compiled CSS because it was excluded via the `exclude()` mixin.

This mixin accepts strings and (nested) lists as an argument. So you can do something like this:

``` scss
@include exclude(
  seed-button,
  seed-list,
  seed-dropdown,
  seed-spacing
);
```

All of the above mentioned modules (packs) will be excluded from the rendered CSS.

**Note:** You must use `exclude` **before** your export/published modules. Excluding things after the fact doesn't work because CSS is compiled top to bottom.
